### PR TITLE
Feature: true substratum fetching by node click

### DIFF
--- a/client/lib/io/stream.js
+++ b/client/lib/io/stream.js
@@ -29,7 +29,7 @@ exports.connect = function () {
   graphStream = new window.EventSource(STREAM_URL)
   graphStream.addEventListener(STREAM_KEY, function (ev) {
     const data = JSON.parse(ev.data)
-    console.log('Received an event with data:', data)
+    console.log('Received a SSE event with data:', data)
 
     // Check event format
     if (data && data.path) {
@@ -42,7 +42,7 @@ exports.connect = function () {
       } else {
         // No handlers set for the path.
         // In development, we like to know if this happens.
-        console.warn('Received an event with unregisterd path: ' + path)
+        console.warn('Received a SSE event with unregisterd path: ' + path)
       }
     } else {
       // In development, we'd like to know if ev has no path.

--- a/client/lib/strata/index.js
+++ b/client/lib/strata/index.js
@@ -21,8 +21,20 @@ exports.build = function () {
   const space = tapspace.createSpace(sky)
   const view = space.getViewport()
 
-  const createStratum = function (path, context, label, bgColor) {
+  const createStratum = function (path, context, label, bgColor, position) {
     // Create and start one stratum.
+    //
+    // Parameters:
+    //   path
+    //     string, identifies the stratum
+    //   context
+    //     object
+    //   label
+    //     string, label for the root node
+    //   bgColor
+    //     string, css color for the root node
+    //   position
+    //     tapspace Point, the position of the root node.
     //
     // Return:
     //   a stratum. If a stratum with the path already exists, the existing
@@ -38,7 +50,8 @@ exports.build = function () {
     }
 
     // Build and render
-    const stratum = stratumLib.buildStratum(path, context, label, bgColor, space)
+    const stratum = stratumLib.buildStratum(path, context, label,
+      bgColor, position, space)
 
     // Keep track of what strata we have built.
     state.strata['/'] = stratum
@@ -51,7 +64,7 @@ exports.build = function () {
       // Stratum build might be heavy. To avoid blocking click interaction
       // too long, place the build last in the event loop. Thus timeout 0.
       setTimeout(() => {
-        createStratum(ev.path, ev.context, ev.label, ev.bgColor)
+        createStratum(ev.path, ev.context, ev.label, ev.bgColor, ev.position)
       }, 0)
     })
 
@@ -77,10 +90,8 @@ exports.build = function () {
     })
   }
 
-  const firstStratum = createStratum('/', {}, 'ARC', '#444444')
-
-  // Center viewport to stratum.
-  firstStratum.div.affine.translateTo(view.atCenter())
+  // Begin from root stratum /
+  const firstStratum = createStratum('/', {}, 'ARC', '#444444', view.atCenter())
 
   // Once the first stratum has been rendered and we have some content in space,
   // make the viewport interactive and begin refreshing labels.

--- a/client/lib/strata/index.js
+++ b/client/lib/strata/index.js
@@ -1,5 +1,6 @@
 const stratumLib = require('./stratum')
 const tapspace = require('tapspace')
+const initViewport = require('./initViewport')
 
 exports.build = function () {
   // State - the global context.
@@ -40,22 +41,7 @@ exports.build = function () {
     // const stratum_plane = stratum.div.affine
     // stratum_plane.scaleToFit(view)
 
-    // Make viewport zoomable after rendered
-    view.zoomable()
-    // Make viewport maintain the center under window resize
-    view.responsive()
-    // Make viewport use perspective projection.
-    view.perspective()
-
-    // Add basic zoom control
-    const zoomControl = new tapspace.components.ZoomControl({
-      scaleStep: 1.5
-    })
-    view.addControl(zoomControl)
-    zoomControl.match({
-      source: zoomControl.atBottomRight(),
-      target: view.atBottomRight().offset(-10, -10)
-    })
+    initViewport(view)
 
     // Show/hide labels after zoom
     stratumLib.semanticZoom(stratum, space)

--- a/client/lib/strata/initViewport.js
+++ b/client/lib/strata/initViewport.js
@@ -1,0 +1,28 @@
+const tapspace = require('tapspace')
+
+module.exports = (view) => {
+  // This function prepares the tapspace viewport for interaction
+  // and navigation. We would like to avoid user to interact with
+  // the viewport before there is something to show. Otherwise
+  // a few accidental moves could pan the viewport somewhere
+  // where there is no content.
+  // Therefore, favorably call the function only after the space has content.
+  //
+
+  // Make viewport zoomable after rendered
+  view.zoomable()
+  // Make viewport maintain the center under window resize
+  view.responsive()
+  // Make viewport use perspective projection.
+  view.perspective()
+
+  // Add basic zoom control
+  const zoomControl = new tapspace.components.ZoomControl({
+    scaleStep: 1.5
+  })
+  view.addControl(zoomControl)
+  zoomControl.match({
+    source: zoomControl.atBottomRight(),
+    target: view.atBottomRight().offset(-10, -10)
+  })
+}

--- a/client/lib/strata/stratum/index.js
+++ b/client/lib/strata/stratum/index.js
@@ -4,6 +4,10 @@ const emitter = require('component-emitter')
 const io = require('../../io')
 
 exports.buildStratum = function (path, context, label, bgColor, space) {
+  // Create a stratum object.
+  //
+  // Stratum inherits Emitter
+  //
   // Parameters:
   //   path
   //     string, the stratum id
@@ -15,6 +19,13 @@ exports.buildStratum = function (path, context, label, bgColor, space) {
   //     string, css color
   //   space
   //     a tapspace space on which to draw the graph
+  //
+  // Stratum emits:
+  //   final
+  //     when all subgraphs of the stratum has been loaded and rendered
+  //   stratumrequest
+  //     when the stratum would like one of its nodes to be opened as
+  //     a new stratum.
   //
 
   // Build valid html-friendly id

--- a/client/lib/strata/stratum/index.js
+++ b/client/lib/strata/stratum/index.js
@@ -3,7 +3,7 @@ const view = require('./view')
 const emitter = require('component-emitter')
 const io = require('../../io')
 
-exports.buildStratum = function (path, context, label, bgColor, space) {
+exports.buildStratum = function (path, context, label, bgColor, position, space) {
   // Create a stratum object.
   //
   // Stratum inherits Emitter
@@ -17,8 +17,10 @@ exports.buildStratum = function (path, context, label, bgColor, space) {
   //     string
   //   bgColor
   //     string, css color
+  //   position
+  //     a tapspace Point at which to draw the graph
   //   space
-  //     a tapspace space on which to draw the graph
+  //     a tapspace space on which to place the graph
   //
   // Stratum emits:
   //   final
@@ -62,7 +64,7 @@ exports.buildStratum = function (path, context, label, bgColor, space) {
       // Refresh the layout
       model.performLayout(stratum.graph, isFinal)
       // Render the graph
-      view.drawGraph(stratum, isFinal)
+      view.drawGraph(stratum, position, isFinal)
 
       // Emit 'final' event if last message
       if (isFinal) stratum.emit('final')

--- a/client/lib/strata/stratum/view/drawGraph.js
+++ b/client/lib/strata/stratum/view/drawGraph.js
@@ -90,32 +90,34 @@ module.exports = function (stratum, final = false) {
     // Add click event for facetable nodes
     const facetableNodes = document.querySelectorAll('.node[data-facet_param]')
     const facetableClickHandler = (event) => {
+      const clickedNodeId = event.target.id
+      const facetPath = clickedNodeId.replaceAll('_', '/')
       const facetParam = event.target.getAttribute('data-facet_param')
       const facetValue = event.target.getAttribute('data-facet_value')
       const context = {}
       context[`f_${facetParam}`] = facetValue
-      console.log(`To create the newly faceted stratum, I'm assuming we'd call "build_stratum" with the following params:
-  path: "${event.target.id.replaceAll('_', '/')}"
-  context: ${context}
-  label: "to be determined"
-  bgColor: "to be determined"
-  space: ?
-      `)
 
-      // TODO The click should emit an event, let's say "substratum-requested",
-      // and that event should be listened at strata/ level, so that individual
-      // stratum does not need to know about or control other strata.
-
-      // TEMP For demonstrative purposes, until true substratum rendering
-      // is implemented, let a click add something below the clicked node.
       const nodeItem = tapspace.components.Basis.findAffineAncestor(event.target)
       if (nodeItem) {
+        // TEMP For demonstrative purposes, until true substratum rendering
+        // is implemented, let a click add something below the clicked node.
         const protoStratum = tapspace.createCircle(10, 'white')
         const protoPosition = nodeItem.atCenter().offset(0, 0, 30)
         nodeGroup.addChild(protoStratum, protoPosition)
         console.log('Proto stratum rendered')
+
+        // The click emits an event "stratumrequest" which is listened on
+        // strata-level, so that individual stratum does not need to know
+        // about or control other strata.
+        stratum.emit('stratumrequest', {
+          path: facetPath,
+          context: context,
+          label: 'todo',
+          bgColor: 'todo'
+        })
       }
     }
+
     facetableNodes.forEach(facetableNode => {
       facetableNode.removeEventListener('click', facetableClickHandler)
       facetableNode.addEventListener('click', facetableClickHandler)

--- a/client/lib/strata/stratum/view/drawGraph.js
+++ b/client/lib/strata/stratum/view/drawGraph.js
@@ -4,29 +4,33 @@ const nodeSize = require('./node/nodeSize')
 const generateNodeId = require('./node/generateNodeId')
 const generateEdgeId = require('./edge/generateEdgeId')
 
-module.exports = function (stratum, final = false) {
+module.exports = function (stratum, position, final = false) {
   // Render the graph. If elements already exist, update.
   //
   // Parameters:
   //   stratum
   //     a stratum object with 'path', 'div', and 'graph' properties
+  //   position
+  //     a tapspace Point at which to draw the root node
   //   final
   //     boolean, set true to update edges
   //
   const div = stratum.div
   const stratumPlane = div.affine
+  const stratumOrigin = position.changeBasis(stratumPlane)
   const path = stratum.path
   const graph = stratum.graph
 
   const edgeGroup = stratumPlane.edgeGroup
   const nodeGroup = stratumPlane.nodeGroup
 
+  // Map each node in graph model to a visible tapspace item.
   graph.forEachNode(function (key, attrs) {
     // Prefixing node ids with path to prevent id collisions across strata
     const nId = generateNodeId(path, key)
     const nElem = document.getElementById(nId)
 
-    const nPosition = stratumPlane.at(attrs.x, attrs.y)
+    const nPosition = stratumOrigin.offset(attrs.x, attrs.y)
     const nSize = nodeSize(attrs)
 
     if (nElem) {
@@ -99,21 +103,16 @@ module.exports = function (stratum, final = false) {
 
       const nodeItem = tapspace.components.Basis.findAffineAncestor(event.target)
       if (nodeItem) {
-        // TEMP For demonstrative purposes, until true substratum rendering
-        // is implemented, let a click add something below the clicked node.
-        const protoStratum = tapspace.createCircle(10, 'white')
-        const protoPosition = nodeItem.atCenter().offset(0, 0, 30)
-        nodeGroup.addChild(protoStratum, protoPosition)
-        console.log('Proto stratum rendered')
-
         // The click emits an event "stratumrequest" which is listened on
         // strata-level, so that individual stratum does not need to know
         // about or control other strata.
+        const position = nodeItem.atCenter().offset(0, 0, 30)
         stratum.emit('stratumrequest', {
           path: facetPath,
           context: context,
           label: 'todo',
-          bgColor: 'todo'
+          bgColor: 'todo',
+          position: position
         })
       }
     }

--- a/client/lib/strata/stratum/view/edge/generateEdgeId.js
+++ b/client/lib/strata/stratum/view/edge/generateEdgeId.js
@@ -10,5 +10,12 @@ module.exports = function (stratumPath, edgeKey) {
   // Return
   //   a string, suitable for HTMLElement id.
   //
-  return `${stratumPath}${edgeKey}`.replaceAll('/', '_')
+
+  // Remove trailing slash.
+  // Root is a special path as it begins and ends with the same slash.
+  if (stratumPath.endsWith('/')) {
+    stratumPath = stratumPath.substring(0, stratumPath.length - 1)
+  }
+
+  return (stratumPath + edgeKey).replaceAll('/', '_')
 }

--- a/client/lib/strata/stratum/view/node/generateNodeId.js
+++ b/client/lib/strata/stratum/view/node/generateNodeId.js
@@ -10,5 +10,12 @@ module.exports = function (stratumPath, nodeKey) {
   // Return
   //   a string, suitable for HTMLElement id.
   //
-  return `${stratumPath}${nodeKey}`.replaceAll('/', '_')
+
+  // Remove trailing slash.
+  // Root is a special path as it begins and ends with the same slash.
+  if (stratumPath.endsWith('/')) {
+    stratumPath = stratumPath.substring(0, stratumPath.length - 1)
+  }
+
+  return (stratumPath + nodeKey).replaceAll('/', '_')
 }


### PR DESCRIPTION
Changes in brief:
- stratum objects emits `stratumrequest` event with data when one of their facetable nodes is clicked.
- the strata object acts as a mediator/manager: it listens for stratumrequest events and reacts by creating a new substratum.
- a stratum can be rendered to a specific point in space.
- repaired path-to-id-to-path conversions which wrongly produced paths like `//arc/federations` instead of `/arc/federations`.

The following might be necessary to purge the docker container:
```
$ docker-compose down --volumes
$ docker-compose up --build
```