### PR TITLE
Feature: repair proximity-sensitive labels and stratum path handling 

### DIFF
--- a/client/lib/strata/index.js
+++ b/client/lib/strata/index.js
@@ -54,7 +54,7 @@ exports.build = function () {
       bgColor, position, space)
 
     // Keep track of what strata we have built.
-    state.strata['/'] = stratum
+    state.strata[path] = stratum
     state.strataTrail.push(stratum.path)
     state.currentStratum = state.strataTrail.length - 1
 

--- a/client/lib/strata/stratum/index.js
+++ b/client/lib/strata/stratum/index.js
@@ -78,7 +78,9 @@ exports.buildStratum = function (path, context, label, bgColor, position, space)
 }
 
 exports.semanticZoom = (stratum, space) => {
+  const viewport = space.getViewport()
+
   if (stratum.alive) {
-    view.refreshLabels(stratum, space)
+    view.refreshLabels(stratum, viewport)
   }
 }

--- a/client/lib/strata/stratum/view/refreshLabels.js
+++ b/client/lib/strata/stratum/view/refreshLabels.js
@@ -1,25 +1,25 @@
-module.exports = function (stratum, space) {
+module.exports = function (stratum, viewport) {
   // Show/hide labels depending on visible node size.
   //
   // Parameters:
   //   stratum
   //     a stratum object
-  //   space
-  //     a tapspace space, required for finding node size relative to viewport.
+  //   viewport
+  //     a tapspace viewport, required for finding node size relative to it.
   //
   const stratumPlane = stratum.div.affine
   const nodes = stratumPlane.nodeGroup.getChildren() // HACKY
 
   nodes.forEach((node) => {
     // Determine node size on viewport.
-    const size = node.getWidth() // a Distance on node
-    const sizeOnViewport = size.changeBasis(space).getRaw()
+    const width = node.getWidth() // a Distance on node
+    const widthOnViewport = width.changeBasis(viewport).getRaw()
 
     // Show if large enough, ensure hidden otherwise.
     const label = node.getElement().querySelector('.label')
     // Check that label exists.
     if (label) {
-      if (sizeOnViewport >= 20) {
+      if (widthOnViewport >= 20) {
         label.style.display = 'inline'
       } else {
         label.style.display = 'none'

--- a/client/lib/strata/stratum/view/refreshLabels.js
+++ b/client/lib/strata/stratum/view/refreshLabels.js
@@ -11,15 +11,21 @@ module.exports = function (stratum, viewport) {
   const nodes = stratumPlane.nodeGroup.getChildren() // HACKY
 
   nodes.forEach((node) => {
+    const trip = viewport.atCamera().getVectorTo(node.atCenter())
+    const tripDeltaZ = trip.transitRaw(viewport).z
+
     // Determine node size on viewport.
-    const width = node.getWidth() // a Distance on node
-    const widthOnViewport = width.changeBasis(viewport).getRaw()
+    const width = node.getWidth().getRaw() // px
+
+    // TODO Replace with true, projected node size on viewport in pixels,
+    // TODO so that the label threshold is based on font size.
+    const indicator = tripDeltaZ - width * width
 
     // Show if large enough, ensure hidden otherwise.
     const label = node.getElement().querySelector('.label')
     // Check that label exists.
     if (label) {
-      if (widthOnViewport >= 20) {
+      if (indicator < 100) {
         label.style.display = 'inline'
       } else {
         label.style.display = 'none'


### PR DESCRIPTION
Minor repairs to frontend code:
- before fix, each stratum was registered with path "/" instead their own path like "/arc/disciplines".
- label visibility is now based on camera distance and node area (in future: base on pixel size on screen)